### PR TITLE
✨ Update Nexus

### DIFF
--- a/src/ArchNexus.sol
+++ b/src/ArchNexus.sol
@@ -204,7 +204,10 @@ contract ArchNexus is IArchNexus, Ownable, ReentrancyGuard {
 
         if (_finalToken == address(wrappedNativeToken) && isNativeToken) {
             wrappedNativeToken.withdraw(finalAmountBought);
-            address(msg.sender).call{ value: finalAmountBought }("");
+            (bool success,) = address(msg.sender).call{ value: finalAmountBought }("");
+            if (!success) {
+                revert NativeTransferFailed();
+            }
         } else {
             finalToken.safeTransfer(msg.sender, finalAmountBought);
         }
@@ -250,7 +253,10 @@ contract ArchNexus is IArchNexus, Ownable, ReentrancyGuard {
 
         wrappedNativeToken.withdraw(remainingWrappedBalance);
 
-        address(msg.sender).call{ value: remainingWrappedBalance }("");
+        (bool success,) = address(msg.sender).call{ value: remainingWrappedBalance }("");
+        if (!success) {
+            revert NativeTransferFailed();
+        }
 
         finalAmountBought = finalToken.balanceOf(address(this)) - finalTokenBalanceBefore;
 

--- a/src/ArchNexus.sol
+++ b/src/ArchNexus.sol
@@ -177,7 +177,8 @@ contract ArchNexus is IArchNexus, Ownable, ReentrancyGuard {
         address _baseToken,
         uint256 _baseAmount,
         address _finalToken,
-        uint256 _minFinalAmount
+        uint256 _minFinalAmount,
+        bool isNativeToken
     ) external nonReentrant returns (uint256 finalAmountBought) {
         if (_baseAmount == 0) revert ZeroBaseTokenSent();
         if (_baseToken == _finalToken) revert NoSameAddressAllowed();
@@ -199,6 +200,13 @@ contract ArchNexus is IArchNexus, Ownable, ReentrancyGuard {
 
         if (finalAmountBought < _minFinalAmount) {
             revert UnderboughtAsset(finalToken, _minFinalAmount);
+        }
+
+        if (_finalToken == address(wrappedNativeToken) && isNativeToken) {
+            wrappedNativeToken.withdraw(finalAmountBought);
+            address(msg.sender).call{ value: finalAmountBought }("");
+        } else {
+            finalToken.safeTransfer(msg.sender, finalAmountBought);
         }
 
         finalToken.safeTransfer(msg.sender, finalAmountBought);
@@ -227,15 +235,24 @@ contract ArchNexus is IArchNexus, Ownable, ReentrancyGuard {
         if (_finalToken == address(0)) revert ZeroAddressNotAllowed();
         if (_contractCallInstructions.length == 0) revert NoInstructionsProvided();
 
+        uint256 wrappedBalanceBefore = wrappedNativeToken.balanceOf(address(this));
+
         wrappedNativeToken.deposit{ value: msg.value }();
-
-        _executeInstructions(_contractCallInstructions);
-
-        wrappedNativeToken.transfer(msg.sender, wrappedNativeToken.balanceOf(address(this)));
 
         IERC20 finalToken = IERC20(_finalToken);
 
-        finalAmountBought = finalToken.balanceOf(address(this));
+        uint256 finalTokenBalanceBefore = finalToken.balanceOf(address(this));
+
+        _executeInstructions(_contractCallInstructions);
+
+        uint256 remainingWrappedBalance =
+            wrappedNativeToken.balanceOf(address(this)) - wrappedBalanceBefore;
+
+        wrappedNativeToken.withdraw(remainingWrappedBalance);
+
+        address(msg.sender).call{ value: remainingWrappedBalance }("");
+
+        finalAmountBought = finalToken.balanceOf(address(this)) - finalTokenBalanceBefore;
 
         if (finalAmountBought < _minFinalAmount) {
             revert UnderboughtAsset(finalToken, _minFinalAmount);

--- a/src/interfaces/IArchNexus.sol
+++ b/src/interfaces/IArchNexus.sol
@@ -98,6 +98,8 @@ interface IArchNexus {
 
     error NoInstructionsProvided();
 
+    error NativeTransferFailed();
+
     /*//////////////////////////////////////////////////////////////
                                 FUNCTIONS
     //////////////////////////////////////////////////////////////*/
@@ -119,7 +121,8 @@ interface IArchNexus {
         address _baseToken,
         uint256 _baseAmount,
         address _finalToken,
-        uint256 _minFinalAmount
+        uint256 _minFinalAmount,
+        bool isNativeToken
     ) external returns (uint256 finalAmountBought);
 
     function executeCallsWithNativeToken(

--- a/test/ArchNexus/ArchNexus.hackyWacky.t.sol
+++ b/test/ArchNexus/ArchNexus.hackyWacky.t.sol
@@ -65,7 +65,7 @@ contract HackyWackyTests is ArchNexusTest {
         vm.expectRevert(
             abi.encodeWithSelector(IArchNexus.InvalidTarget.selector, address(malicious))
         );
-        archNexus.executeCalls(calls, WETH, 1, ADDY, 0);
+        archNexus.executeCalls(calls, WETH, 1, ADDY, 0, false);
         vm.stopPrank();
 
         // validate that the hacker did not withdraw the balance
@@ -106,7 +106,7 @@ contract HackyWackyTests is ArchNexusTest {
         // execute
         vm.startPrank(hacker);
         IERC20(WETH).approve(address(archNexus), 100 ether);
-        archNexus.executeCalls(calls, WETH, 1, ADDY, 0);
+        archNexus.executeCalls(calls, WETH, 1, ADDY, 0, false);
         vm.stopPrank();
 
         // validate that the hacker did not withdraw the balance


### PR DESCRIPTION
## Summary
- Allow native token as final token for executeCalls
- Return native token instead of wrapped for remaining balance in executeCallsWithNative